### PR TITLE
add change_password

### DIFF
--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -128,7 +128,7 @@ class Client(object):
             'Accept': 'text/plain'
         }
 
-        data = {'new_password': new_password, 'old_password': old_password, 'user':username}
+        data = {'user': username, 'new_password': new_password, 'old_password': old_password}
         response = self._session.post(password_url, headers=headers, data=data, verify=self._verify_ssl)
 
         if not response.ok:

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -127,8 +127,15 @@ class Client(object):
             'Content-Type': 'application/x-www-form-urlencoded',
             'Accept': 'text/plain'
         }
+
         data = {'new_password': new_password, 'old_password': old_password, 'user':username}
         response = self._session.post(password_url, headers=headers, data=data, verify=self._verify_ssl)
+
+        if not response.ok:
+            raise FreeIPAError(message=response.content, code=response.status_code)
+                
+        if response.headers.get('X-IPA-Pwchange-Result', None) != 'ok':
+            raise FreeIPAError(message=response.content, code=response.status_code)
         return response
 
     def user_add(self, username, first_name, last_name, full_name, display_name=None,

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -110,6 +110,27 @@ class Client(object):
         else:
             return result['result']
 
+    def change_password(self, username, new_password, old_password):
+        """
+        Set the password of a user. (Does not expire)
+
+        :param login: User login (username)
+        :type login: string
+        :param password: New password for the user
+        :type password: string
+        :param old_password: Users old password
+        :type old_password: string
+        """
+
+        password_url = '{0}/session/change_password'.format(self._base_url)
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'text/plain'
+        }
+        data = {'new_password': new_password, 'old_password': old_password, 'user':username}
+        response = self._session.post(password_url, headers=headers, data=data, verify=self._verify_ssl)
+        return response
+
     def user_add(self, username, first_name, last_name, full_name, display_name=None,
                  noprivate=False, mail=None, ssh_key=None, job_title=None,
                  preferred_language=None, disabled=False, random_pass=False, **kwargs):


### PR DESCRIPTION
The api endpoint `passwd` sets the password to expire instantly, But I would like to be able to change the password without it expiring. This PR uses the same endpoint that FreeIPA uses when passwords expire. 

Not sure if this should be implemented as a different function or the functionality merged with passwd.

Made a PR mostly for discussion, so not suprised if it doesn't get merged.