### PR TITLE
Support for Kerberos authentication and logout

### DIFF
--- a/src/python_freeipa/__init__.py
+++ b/src/python_freeipa/__init__.py
@@ -1,1 +1,1 @@
-from .client import Client  # NOQA
+from .client import Client, AuthenticatedSession  # NOQA

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -113,7 +113,9 @@ class Client(object):
             'Accept': 'application/json'
         }
 
-        if not isinstance(args, list):
+        if not args:
+            args = []
+        elif not isinstance(args, list):
             args = [args]
 
         if not params:

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -24,7 +24,7 @@ class AuthenticatedSession(object):
     """
     Context manager class that automatically logs out upon exit.
     """
-    def __init__(self, client, *login_arguments, logged_in=False):
+    def __init__(self, client, *login_arguments, **kwargs):
         """
         Constructs a new authenticated session with optional login arguments.
 
@@ -40,7 +40,7 @@ class AuthenticatedSession(object):
         """
         self._client = client
         self._login_args = login_arguments
-        self._logged_in = logged_in
+        self._logged_in = kwargs.get('logged_in', False)
         self._login_exception = None
 
     @property

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -29,11 +29,11 @@ class AuthenticatedSession(object):
         Constructs a new authenticated session with optional login arguments.
 
         When the ``__enter__`` method of is invoked, if the parameter ``logged_in`` is False, the class will attempt to
-        login using the specified ``login_arguments`` (e.g. username and password) through :meth:`.Client.login`. If no
-        login arguments is specified, it will attempt a Kerberos login via :meth:`.Client.login_kerberos`.
+        login using the specified ``login_arguments`` (e.g. username and password) through ``Client.login``. If no
+        login arguments is specified, it will attempt a Kerberos login via ``Client.login_kerberos``.
 
         :param client: an instance of a FreeIPA client
-        :type client: :class:`.Client`
+        :type client: ``Client``
         :param login_arguments: arguments to use to login upon enter, possibly empty.
         :param logged_in: True if the instance ``client`` is already logged in.
         :type logged_in: bool
@@ -69,7 +69,7 @@ class AuthenticatedSession(object):
         """
         Tries to perform a login, if necessary, using the login arguments specified at cosntruction.
 
-        This method does not throw, but will store any occurring exception in :meth:`.login_exception`.
+        This method does not throw, but will store any occurring exception in ``login_exception``.
         """
         if not self.logged_in:
             try:
@@ -158,7 +158,7 @@ class Client(object):
             'Referer': self._base_url
         }
         response = self._session.post(login_url, headers=headers, verify=self._verify_ssl,
-            auth=requests_kerberos.HTTPKerberosAuth())
+                                      auth=requests_kerberos.HTTPKerberosAuth())
 
         if not response.ok:
             raise Unauthorized(response.text)

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -67,7 +67,7 @@ class AuthenticatedSession(object):
 
     def __enter__(self):
         """
-        Tries to perform a login, if necessary, using the login arguments specified at cosntruction.
+        Tries to perform a login, if necessary, using the login arguments specified at construction.
 
         This method does not throw, but will store any occurring exception in ``login_exception``.
         """

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -92,6 +92,12 @@ class Client(object):
 
         logger.info('Successfully logged using Kerberos credentials.')
 
+    def logout(self):
+        """
+        Logs out of the FreeIPA session.
+        """
+        self._request('session_logout')
+
     def _request(self, method, args=None, params=None):
         """
         Make an HTTP request to FreeIPA JSON RPC server.


### PR DESCRIPTION
This PR closes #2; it uses `requests_kerberos` only if available, doesn't directly depend on it. If the package is not available, calling `login_kerberos` raises an error.

Login via Kerberos [seems pretty straightforward](https://vda.li/en/docs/freeipa-management-in-a-nutshell/#authentication-and-session-management), it's associated to the session cookie.

One functionality that was missing, is the API [`session_logout`](https://pagure.io/freeipa/c/9753fd423059e8d5725ead9a90a7cf1b9e0b9b85) which will reset the authenticated session on the IPA side; it may be useful to make sure that the session was closed. So I added also a context-managed `AuthenticatedSession`:

```python
from python_freeipa import Client, AuthenticatedSession

c = Client('ipa.example.org')

# Now logged out, can enter a logged in context by calling any login* method:
with c.login_kerberos(): 
    c.do_stuff_while_logged_in()

# Now logged out, can enter a logged in context by directly creating the session
with AuthenticatedSession(c, 'user', 'pass'):
    c.do_stuff_while_logged_in()

# Now logged out
```