### PR TITLE
Update group attributes even if they are empty string

### DIFF
--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -769,16 +769,16 @@ class Client(object):
         """
         params = {'all': True}
 
-        if description:
+        if description is not None:
             params['description'] = description
 
-        if non_posix:
+        if non_posix is not None:
             params['nonposix'] = non_posix
 
-        if external:
+        if external is not None:
             params['external'] = external
 
-        if no_members:
+        if no_members is not None:
             params['no_members'] = no_members
 
         params.update(kwargs)


### PR DESCRIPTION
Hi,
This pr addressing a bug that making the client to not update group's description if they set to empty string.