### PR TITLE
Add some more specific exceptions on login failure

### DIFF
--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -12,12 +12,10 @@ except ImportError as e:
     requests_kerberos = e
 
 from .exceptions import (
-    DuplicateEntry, FreeIPAError, Unauthorized,
-    PasswordExpired, KrbPrincipalExpired, Denied,
-    PWChangeInvalidPassword, PWChangePolicyError,
-    InvalidSessionPassword, UserLocked,
-    parse_error, parse_group_management_error,
-    parse_hostgroup_management_error
+    Denied, DuplicateEntry, FreeIPAError, InvalidSessionPassword,
+    KrbPrincipalExpired, PWChangeInvalidPassword, PWChangePolicyError,
+    PasswordExpired, Unauthorized, UserLocked, parse_error,
+    parse_group_management_error, parse_hostgroup_management_error
 )
 
 logger = logging.getLogger(__name__)

--- a/src/python_freeipa/exceptions.py
+++ b/src/python_freeipa/exceptions.py
@@ -17,9 +17,11 @@ class FreeIPAError(Exception):
         """Serialize exception to string using it's message."""
         return self.message
 
+
 class PWChangeInvalidPassword(FreeIPAError):
     """Raised when the current password is not correct while trying to change
     passwords."""
+
 
 class PWChangePolicyError(FreeIPAError):
     """Raised when changing a password but the new password doesn't fit the
@@ -31,6 +33,7 @@ class PWChangePolicyError(FreeIPAError):
             self.policy_error = policy_error
         super(PWChangePolicyError, self).__init__(message=message, code=code)
 
+
 class BadRequest(FreeIPAError):
     """General purpose exception class."""
 
@@ -40,24 +43,30 @@ class Unauthorized(BadRequest):
 
     message = 'Unauthorized: bad credentials.'
 
+
 class PasswordExpired(Unauthorized):
     """Raised when logging in with an expired password."""
 
     message = 'PasswordExpired: password expired.'
 
+
 class KrbPrincipalExpired(Unauthorized):
     """Raised when Kerberos Principal is expired."""
+
 
 class Denied(Unauthorized):
     """Raised on ACI authorization error."""
 
+
 class InvalidSessionPassword(Unauthorized):
     """Raised when IPA cannot obtain a TGT for a principal."""
+
 
 class UserLocked(Unauthorized):
     """Raised when a user account is locked."""
 
     message = 'UserLocked: user account is locked.'
+
 
 class NotFound(BadRequest):
     """Raised when an entry is not found."""

--- a/src/python_freeipa/exceptions.py
+++ b/src/python_freeipa/exceptions.py
@@ -17,6 +17,19 @@ class FreeIPAError(Exception):
         """Serialize exception to string using it's message."""
         return self.message
 
+class PWChangeInvalidPassword(FreeIPAError):
+    """Raised when the current password is not correct while trying to change
+    passwords."""
+
+class PWChangePolicyError(FreeIPAError):
+    """Raised when changing a password but the new password doesn't fit the
+    password policy."""
+
+    # Carry along some extra information about the policy error.
+    def __init__(self, message=None, code=None, policy_error=None):
+        if policy_error:
+            self.policy_error = policy_error
+        super(PWChangePolicyError, self).__init__(message=message, code=code)
 
 class BadRequest(FreeIPAError):
     """General purpose exception class."""

--- a/src/python_freeipa/exceptions.py
+++ b/src/python_freeipa/exceptions.py
@@ -27,6 +27,24 @@ class Unauthorized(BadRequest):
 
     message = 'Unauthorized: bad credentials.'
 
+class PasswordExpired(Unauthorized):
+    """Raised when logging in with an expired password."""
+
+    message = 'PasswordExpired: password expired.'
+
+class KrbPrincipalExpired(Unauthorized):
+    """Raised when Kerberos Principal is expired."""
+
+class Denied(Unauthorized):
+    """Raised on ACI authorization error."""
+
+class InvalidSessionPassword(Unauthorized):
+    """Raised when IPA cannot obtain a TGT for a principal."""
+
+class UserLocked(Unauthorized):
+    """Raised when a user account is locked."""
+
+    message = 'UserLocked: user account is locked.'
 
 class NotFound(BadRequest):
     """Raised when an entry is not found."""
@@ -55,6 +73,11 @@ class UnknownOption(BadRequest):
 
 
 error_codes = {
+    1201: InvalidSessionPassword,
+    1202: PasswordExpired,
+    1203: KrbPrincipalExpired,
+    1204: UserLocked,
+    2100: Denied,
     3005: UnknownOption,
     3009: ValidationError,
     4001: NotFound,


### PR DESCRIPTION
Signed-off-by: Rick Elrod <rick@elrod.me>

This allows for catching things like expired passwords.
These all subclass `Unauthorized`, so in theory this should hopefully be a non-breaking change for those who catch that.