### PR TITLE
fix dnsdiscovery, use host.hostname (fqdn) instead of host.host (ip) …

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,7 @@ For DNS service discovery, you need to have the "srvlookup" module installed
 .. code-block:: python
 
     from python_freeipa import Client
-    client = Client(version='2.215', dns_lookup=True)
+    client = Client(version='2.215', dns_discovery=True)
     client.login('admin', 'Secret123')
     user = client.user_add('test3', 'John', 'Doe', 'John Doe', preferred_language='EN')
     print(user)

--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -173,8 +173,8 @@ class Client(object):
         else:
             for host in self.dns_discovered:
                 try:
-                    self._current_host = host.host
-                    return self._login(host.host, username, password)
+                    self._current_host = host.hostname
+                    return self._login(host.hostname, username, password)
                 except requests.exceptions.ConnectionError as err:
                     self.log.warning("could not connect discovered host: {0}".format(err))
             raise FreeIPAError("could not connect to any host")
@@ -230,8 +230,8 @@ class Client(object):
         else:
             for host in self.dns_discovered:
                 try:
-                    self._current_host = host.host
-                    return self._login_kerberos(host.host)
+                    self._current_host = host.hostname
+                    return self._login_kerberos(host.hostname)
                 except requests.exceptions.ConnectionError as err:
                     self.log.warning("could not connect discovered host: {0}".format(err))
             raise FreeIPAError("could not connect to any host")


### PR DESCRIPTION
…to prevent certificate issues

and fix documentation on dns discovery (dns_discovery vs dns_lookup)