### PR TITLE
Add srvlookup and requests-gssapi to install_requires (needed for DNS discovery)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'requests',
+    'srvlookup',
+    'requests-gssapi',
 ]
 
 


### PR DESCRIPTION
This adds

* srvlookup
* requests-gssapi

to the `install_requires` variable. The packages are required when using DNS discovery. If the packages are missing, errors such as

```
File "/usr/local/lib/python3.10/site-packages/python_freeipa/client.py", line 153, in dns_discovered
except srvlookup.SRVQueryFailure:
AttributeError: 'ModuleNotFoundError' object has no attribute 'SRVQueryFailure'
```
or

```
File "/usr/local/lib/python3.10/site-packages/python_freeipa/client.py", line 23, in <module>
import requests_gssapi
ModuleNotFoundError: No module named 'requests_gssapi'
```
might occur.