### PR TITLE
Include the Referer in the headers for password changes

### DIFF
--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -361,6 +361,7 @@ class Client(object):
             self.current_host
         )
         headers = {
+            'Referer': password_url,
             'Content-Type': 'application/x-www-form-urlencoded',
             'Accept': 'text/plain',
         }


### PR DESCRIPTION
A [recent commit](https://github.com/freeipa/freeipa/commit/13778d88ca2ac73b729821bdea844172a18c0cb9) in FreeIPA checks the Referrer on more API calls, and it broke the change_password method. This is the fix.